### PR TITLE
Update capabilities and fix them for geckodriver/firefox

### DIFF
--- a/lib/hound/browsers/firefox.ex
+++ b/lib/hound/browsers/firefox.ex
@@ -9,6 +9,6 @@ defmodule Hound.Browser.Firefox do
 
   def default_capabilities(ua) do
     {:ok, profile} = Profile.new |> Profile.set_user_agent(ua) |> Profile.dump
-    %{firefox_profile: profile}
+    %{"moz:firefoxOptions": %{profile: profile}}
   end
 end

--- a/lib/hound/session.ex
+++ b/lib/hound/session.ex
@@ -22,7 +22,9 @@ defmodule Hound.Session do
   def create_session(browser, opts) do
     capabilities = make_capabilities(browser, opts)
     params = %{
-      desiredCapabilities: capabilities
+      capabilities: %{
+        firstMatch: [capabilities]
+      }
     }
 
     # No retries for this request
@@ -33,18 +35,23 @@ defmodule Hound.Session do
   @spec make_capabilities(Hound.Browser.t, map | Keyword.t) :: map
   def make_capabilities(browser, opts \\ []) do
     browser = opts[:browser] || browser
-    %{
-      javascriptEnabled: false,
-      version: "",
-      rotatable: false,
-      takesScreenshot: true,
-      cssSelectorsEnabled: true,
-      nativeEvents: false,
-      platform: "ANY"
-    }
+
+    # gecko doesn't support any of these capabilities
+    case Keyword.get(opts, :driver) do
+      "geckodriver" -> %{}
+      _ -> %{
+        javascriptEnabled: false,
+        version: "",
+        rotatable: false,
+        takesScreenshot: true,
+        cssSelectorsEnabled: true,
+        nativeEvents: false,
+        platform: "ANY"
+      }
+    end
     |> Map.merge(Hound.Browser.make_capabilities(browser, opts))
-    |> Map.merge(opts[:driver] || %{})
   end
+
 
   @doc "Get capabilities of a particular session"
   @spec session_info(String.t) :: map

--- a/lib/hound/session_server.ex
+++ b/lib/hound/session_server.ex
@@ -96,7 +96,10 @@ defmodule Hound.SessionServer do
   end
 
   defp create_session(driver_info, opts) do
-    case Hound.Session.create_session(driver_info[:browser], opts) do
+    # Pass along driver name so capabilities can be altered if needed
+    merged_opts = Keyword.put_new(opts, :driver, driver_info[:driver])
+
+    case Hound.Session.create_session(driver_info[:browser], merged_opts) do
       {:ok, session_id} -> session_id
       {:error, reason} -> raise "could not create a new session: #{reason}, check webdriver is running"
     end


### PR DESCRIPTION
According to the webdriver specification, there is a newer style of capabilities negotiation (alwaysMatch/firstMatch) that should be used instead of desiredCapabilities. The other fixes are to ensure that geckodriver is able to complete the negotiation, since it does not support any of the capabilities which are used by default in this project. This includes a small change to allow `make_capabilities` to know what driver it is using in the first place. Finally, the firefox capabilities map is updated to use the right key.